### PR TITLE
Docs: Improve installation commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ localhost> ssh root@remarkable
 ```bash
 export GORKVERSION=$(curl -s https://api.github.com/repos/owulveryck/goMarkableStream/releases/latest | grep tag_name | awk -F\" '{print $4}')
 curl -L -s https://github.com/owulveryck/goMarkableStream/releases/download/$GORKVERSION/goMarkableStream_${GORKVERSION//v}_linux_arm.tar.gz | tar xzvf - -O goMarkableStream_${GORKVERSION//v}_linux_arm/goMarkableStream > goMarkableStream
-~/ chmod+x goMarkableStream
+chmod +x goMarkableStream
 ./goMarkableStream
 ```
 


### PR DESCRIPTION
- fix typo: `chmod +x` was missing a space
- remove terminal prompt in order to make the lines copy-paste-able